### PR TITLE
Remove calls to create target outcomes form

### DIFF
--- a/ruleLibrary/ADHD/R_ADHDChronicCareWithVanderbiltPWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDChronicCareWithVanderbiltPWS.mlm
@@ -113,7 +113,6 @@ If(TeacherVanderbiltDoneFU = False) then
 call CREATE_JIT with "ADHD TFU";
 endif;
 
-call CREATE_JIT with "TargetOutcomes";
 write ("ADHD follow-up visit. || SEPrompt || || firstname || is due for Vanderbilt assessments from both the parent and teacher (attached). CPT 96110");                                                                                                                                                                                                                                                                                                                   
 write ("Parent Vanderbilt Scanned                      ");
 write ("Teacher Vandrblt to fax                     ");

--- a/ruleLibrary/ADHD/R_ADHDChronicCareWithoutVanderbiltPWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDChronicCareWithoutVanderbiltPWS.mlm
@@ -89,7 +89,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 write ("ADHD follow-up visit. || SEPrompt ||");                                                                                                                                                                                                                                                                                                                   
 write ("Doing Well ->                                           ");
 write ("Follow-up 3-4 mos                    ");

--- a/ruleLibrary/ADHD/R_ADHDMedChangePWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDMedChangePWS.mlm
@@ -79,7 +79,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 write ("|| firstname || has not met target goals for ADHD management, and seems to be experiencing significant side effects.  Confirm this and consider changing the medication.");
 write ("Significant Side Effects ->                       ");
 write ("Change Medication                      ");

--- a/ruleLibrary/ADHD/R_ADHDMedDecreasePWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDMedDecreasePWS.mlm
@@ -86,7 +86,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 write ("|| firstname || has met target goals for ADHD management, but seems to be experiencing significant side effects.  Confirm this and consider decreasing the dose of ADHD meds or changing them.");                                                                                                                                                                                                                                                                                                                   
 write ("Targets Met ->                     ");
 write ("Lower Dose, f/u 2-3 wks                     ");

--- a/ruleLibrary/ADHD/R_ADHDMedTitrationPWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDMedTitrationPWS.mlm
@@ -88,7 +88,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 write ("|| firstname || has not met target goals for ADHD management, and does not seem to be experiencing significant side effects.  Confirm this and consider increasing the dose of ADHD meds.");                                                                                                                                                                                                                                                                                                                   
 write ("Increase Medication Dose ->                      ");
 write ("Follow-up 2-3 wks                     ");

--- a/ruleLibrary/ADHD/R_ADHDMedsAppropriatePWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDMedsAppropriatePWS.mlm
@@ -88,7 +88,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 write ("|| firstname || has met target goals for ADHD management and does not seem to be experiencing significant side effects.  Confirm this and consider moving || firstname || into the chronic care pathway.");                                                                                                                                                                                                                                                                                                                   
 write ("ADHD Well Controlled -->                  ");
 write ("Follow-up 3-4 mos                     ");

--- a/ruleLibrary/ADHD/R_ADHDNoMedTargetNotReachedPWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDNoMedTargetNotReachedPWS.mlm
@@ -79,7 +79,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 write ("|| firstname || has not met target goals for ADHD management, and does not appear to be on medications at this time.");                                                                                                                                                                                                                                                                                                                   
 write ("Increase Behavioral Therapy -> ");
 write ("Follow-up 2-3 wks                     ");

--- a/ruleLibrary/ADHD/R_ADHDNoMedTargetReachedPWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDNoMedTargetReachedPWS.mlm
@@ -84,7 +84,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 write ("|| firstname || has met target goals for ADHD management and does not appear to be on medication. Confirm this and consider moving || firstname || into the chronic care pathway.");                                                                                                                                                                                                                                                                                                                   
 write ("ADHD Well Controlled -->                  ");
 write ("Follow-up 3-4 mos                     ");

--- a/ruleLibrary/ADHD/R_ADHDPreviousDxPWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDPreviousDxPWS.mlm
@@ -112,7 +112,6 @@ If(TeacherVanderbilt = False) then
 call CREATE_JIT with "ADHD TFU";
 endif;
 
-call CREATE_JIT with "TargetOutcomes";
 
 If(preferred_language = Spanish) then
 call CREATE_JIT with "Evaluating ADHD Toolkit Spanish";

--- a/ruleLibrary/ADHD/R_ADHDWorkupCompleteOlderPWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDWorkupCompleteOlderPWS.mlm
@@ -125,7 +125,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 
 If(preferred_language = Spanish) then
 call CREATE_JIT with "Diagnosed Toolkit Spanish";

--- a/ruleLibrary/ADHD/R_ADHDWorkupCompleteYoungerPWS.mlm
+++ b/ruleLibrary/ADHD/R_ADHDWorkupCompleteYoungerPWS.mlm
@@ -121,7 +121,6 @@ endif;
 endif
 ;;
 Action:
-call CREATE_JIT with "TargetOutcomes";
 
 If(preferred_language = Spanish) then
 call CREATE_JIT with "Diagnosed Toolkit Spanish";

--- a/ruleLibrary/ADHD/R_PSFADHDDisruptiveBehaviors.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDDisruptiveBehaviors.mlm
@@ -31,7 +31,7 @@ CurrentStatus := read last {CHICA_ADHD_DX from CHICA} ;
 Target := read last {CHICA_ADHD_Targets from CHICA};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 endif
 ;;
-Priority: 270;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDDisruptiveBehaviorsOlder.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDDisruptiveBehaviorsOlder.mlm
@@ -31,7 +31,7 @@ CurrentStatus := read last {CHICA_ADHD_DX from CHICA} ;
 Target := read last {CHICA_ADHD_Targets from CHICA};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 endif
 ;;
-Priority: 271;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDImprovedAcademics.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDImprovedAcademics.mlm
@@ -31,7 +31,7 @@ CurrentStatus := read last {CHICA_ADHD_DX from CHICA} ;
 Target := read last {CHICA_ADHD_Targets from CHICA};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 endif
 ;;
-Priority: 272;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDImprovedAcademicsOlder.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDImprovedAcademicsOlder.mlm
@@ -31,7 +31,7 @@ CurrentStatus := read last {CHICA_ADHD_DX from CHICA} ;
 Target := read last {CHICA_ADHD_Targets from CHICA};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 endif
 ;;
-Priority: 273;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDImprovedRelationships.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDImprovedRelationships.mlm
@@ -31,7 +31,7 @@ CurrentStatus := read last {CHICA_ADHD_DX from CHICA} ;
 Target := read last {CHICA_ADHD_Targets from CHICA};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 endif
 ;;
-Priority: 274;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDImprovedRelationshipsOlder.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDImprovedRelationshipsOlder.mlm
@@ -31,7 +31,7 @@ CurrentStatus := read last {CHICA_ADHD_DX from CHICA} ;
 Target := read last {CHICA_ADHD_Targets from CHICA};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 endif
 ;;
-Priority: 275;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDImprovedSelfEsteem.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDImprovedSelfEsteem.mlm
@@ -31,7 +31,7 @@ Target := read last {CHICA_ADHD_Targets from CHICA};
 location:= read {location from Parameters};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 endif
 ;;
-Priority: 276;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDImprovedSelfEsteemOlder.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDImprovedSelfEsteemOlder.mlm
@@ -31,7 +31,7 @@ Target := read last {CHICA_ADHD_Targets from CHICA};
 location:= read {location from Parameters};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 endif
 ;;
-Priority: 277;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDIncreasedIndependence.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDIncreasedIndependence.mlm
@@ -31,7 +31,7 @@ CurrentStatus := read last {CHICA_ADHD_DX from CHICA} ;
 Target := read last {CHICA_ADHD_Targets from CHICA};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 endif
 ;;
-Priority: 278;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then

--- a/ruleLibrary/ADHD/R_PSFADHDIncreasedIndependenceOlder.mlm
+++ b/ruleLibrary/ADHD/R_PSFADHDIncreasedIndependenceOlder.mlm
@@ -31,7 +31,7 @@ CurrentStatus := read last {CHICA_ADHD_DX from CHICA} ;
 Target := read last {CHICA_ADHD_Targets from CHICA};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 endif
 ;;
-Priority: 279;;
+Priority: 1000;;
  Evoke: ;;
 Logic:
 If (mode = PRODUCE) then


### PR DESCRIPTION
disable rules that fire due to scanning of the form