### PR TITLE
Chica 450 g3 chica ui updates

### DIFF
--- a/metadata/config.xml
+++ b/metadata/config.xml
@@ -6,7 +6,7 @@
     <!-- Chica Module Properties -->
     <id>chica</id>
     <name>Chica</name>
-    <version>1.63.1</version>
+    <version>1.63.2</version>
     <package>org.openmrs.module.@MODULE_ID@</package>
     <author>Vibha Anand and Tammy Dugan</author>
     <description>

--- a/web/module/CRAFFTMobile.jsp
+++ b/web/module/CRAFFTMobile.jsp
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/chicaMobile.css">
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
+<script src="${pageContext.request.contextPath}/moduleResources/chica/browserFixMobile.js" charset="utf-8"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.blockUI.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/CRAFFTMobile.js" charset="utf-8"></script>

--- a/web/module/MCHATMobile.jsp
+++ b/web/module/MCHATMobile.jsp
@@ -9,6 +9,7 @@
 		<link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.css">
 		<link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/chicaMobile.css">
 		<script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
+		<script src="${pageContext.request.contextPath}/moduleResources/chica/browserFixMobile.js" charset="utf-8"></script>
 		<script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.js"></script>
 		<script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.blockUI.js"></script>
 		<script src="${pageContext.request.contextPath}/moduleResources/chica/MCHATMobile.js" charset="utf-8"></script>

--- a/web/module/externalFormLoader.jsp
+++ b/web/module/externalFormLoader.jsp
@@ -10,6 +10,7 @@
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-ui-1.11.2/jquery-ui.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/externalFormLoader.js"></script>
+<title>CHICA ${formName}</title>
 </head>
 <body>
 
@@ -27,63 +28,63 @@
 	           </c:choose>
                <c:choose>
                    <c:when test="${missingUser eq 'true'}">
-                       <div><p>No user was provided for authentication.</p></div>
+                       <div><p>No CHICA user was provided for authentication.</p></div>
                    </c:when>
                    <c:when test="${missingPassword eq 'true'}">
-                       <div><p>No password was provided for authentication.</p></div>
+                       <div><p>No CHICA password was provided for authentication.</p></div>
                    </c:when>
                    <c:when test="${failedAuthentication eq 'true'}">
-                       <div><p>Invalid username/password provided.</p></div>
+                       <div><p>Invalid username/password provided to the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${missingForm eq 'true'}">
-                       <div><p>A valid formName parameter was not provided.</p></div>
+                       <div><p>A valid formName parameter was not provided to the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${invalidForm eq 'true'}">
-                       <div><p>A form with the name ${formName} cannot be found in the system.</p></div> 
+                       <div><p>A form with the name ${formName} cannot be found in the CHICA system.</p></div> 
                    </c:when>
                    <c:when test="${missingFormPage eq 'true'}">
-                       <div><p>A valid formPage parameter was not provided.</p></div>
+                       <div><p>A valid formPage parameter was not provided to the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${missingMRN eq 'true'}">
-                       <div><p>A valid mrn parameter was not provided.</p></div>
+                       <div><p>A valid mrn parameter was not provided to the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${invalidPatient eq 'true'}">
-                       <div><p>A patient with MRN ${mrn} cannot be found in the system.</p></div>
+                       <div><p>A patient with MRN ${mrn} cannot be found in the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${missingEncounter eq 'true'}">
-                       <div><p>A valid encounter within the past 48 hours cannot be found for patient ${mrn}.</p></div>
+                       <div><p>A valid encounter within the past 48 hours cannot be found for patient ${mrn} in the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${missingFormInstance eq 'true'}">
-                       <div><p>A valid instance of the form ${formname} cannot be found for patient ${mrn}.</p></div>
+                       <div><p>The form ${formname} has already been submitted for patient ${mrn} in the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${missingStartState eq 'true'}">
-                       <div><p>A valid startState parameter was not provided.</p></div>
+                       <div><p>A valid startState parameter was not provided to the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${missingEndState eq 'true'}">
-                       <div><p>A valid endState parameter was not provided.</p></div>
+                       <div><p>A valid endState parameter was not provided to the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${invalidStartState eq 'true'}">
-                       <div><p>A start state with name ${startState} cannot be found in the system.</p></div>
+                       <div><p>A start state with name ${startState} cannot be found in the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${invalidEndState eq 'true'}">
-                       <div><p>An end state with name ${endState} cannot be found in the system.</p></div>
+                       <div><p>An end state with name ${endState} cannot be found in the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${missingProviderId eq 'true'}">
-                       <div><p>A valid providerId parameter was not provided.</p></div>
+                       <div><p>A valid providerId parameter was not provided to the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${invalidProviderId eq 'true'}">
-                       <div><p>A provider with providerId ${providerId} cannot be found in the system.</p></div>
+                       <div><p>A provider with providerId ${providerId} cannot be found in the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${missingVendor eq 'true'}">
-                       <div><p>A valid vendor parameter was not provided.</p></div>
+                       <div><p>A valid vendor parameter was not provided to the CHICA system.</p></div>
                    </c:when>
                    <c:when test="${invalidVendor eq 'true'}">
-                       <div><p>A vendor with name ${vendor} cannot be found in the system.</p></div>
+                       <div><p>A vendor with name ${vendor} cannot be found in the CHICA system.</p></div>
                    </c:when>
                </c:choose>
 	        </c:when>
 	        <c:otherwise>
-	           <div><p>Loading form ${formName} for ${mrn}.  Please wait...</p></div>
+	           <div><p>Loading ${formName} CHICA form for ${mrn}.  Please wait...</p></div>
 	        </c:otherwise>
         </c:choose>
         <br/>

--- a/web/module/finishFormsMobile.jsp
+++ b/web/module/finishFormsMobile.jsp
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/chicaMobile.css">
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
+<script src="${pageContext.request.contextPath}/moduleResources/chica/browserFixMobile.js" charset="utf-8"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/finishFormsMobile.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.timer.js"></script>

--- a/web/module/greaseBoardMobile.jsp
+++ b/web/module/greaseBoardMobile.jsp
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/chicaMobile.css">
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
+<script src="${pageContext.request.contextPath}/moduleResources/chica/browserFixMobile.js" charset="utf-8"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.timer.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/core.js"></script>

--- a/web/module/greaseBoardMobile.jsp
+++ b/web/module/greaseBoardMobile.jsp
@@ -30,7 +30,7 @@
         <div data-role="content">
             <div id="listErrorResultDiv"></div>
             <div style="margin: 0 auto;text-align: center;">
-                <a href="#" data-inline="true" data-rel="back" data-role="button" data-theme="b" style="width: 150px;">OK</a>
+                <a href="#" data-inline="true" onClick="startTimer()" data-role="button" data-theme="b" style="width: 150px;">OK</a>
             </div>
         </div>
     </div>

--- a/web/module/loginMobile.jsp
+++ b/web/module/loginMobile.jsp
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/chicaMobile.css">
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
+<script src="${pageContext.request.contextPath}/moduleResources/chica/browserFixMobile.js" charset="utf-8"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/core.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/aes.js"></script>

--- a/web/module/phq9Mobile.jsp
+++ b/web/module/phq9Mobile.jsp
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/chicaMobile.css">
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
+<script src="${pageContext.request.contextPath}/moduleResources/chica/browserFixMobile.js" charset="utf-8"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.blockUI.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/phq9Mobile.js" charset="utf-8"></script>

--- a/web/module/psfMobileDynamic.jsp
+++ b/web/module/psfMobileDynamic.jsp
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/chicaMobile.css">
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
+<script src="${pageContext.request.contextPath}/moduleResources/chica/browserFixMobile.js" charset="utf-8"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.blockUI.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/psfMobileDynamic.js" charset="utf-8"></script>

--- a/web/module/pws.jsp
+++ b/web/module/pws.jsp
@@ -1143,7 +1143,7 @@
                         <span>Submitting...</span>
                     </div>
                 </div>
-                <div id="formTabDialog" title="Recommended Handouts" class="ui-dialog-titlebar ui-widget-header" style="overflow-x: hidden;">
+                <div id="formTabDialog" title="CHICA Recommended Handouts" class="ui-dialog-titlebar ui-widget-header" style="overflow-x: hidden;">
                     <div id="formTabDialogContainer" style="overflow-x: hidden;overflow-y: hidden;">
 	                    <div id="formLoading">
 	                       <span id="formLoadingPanel"><img src="/openmrs/moduleResources/chica/images/ajax-loader.gif"/>Loading forms...</span>
@@ -1160,7 +1160,7 @@
 	                    </div>
 	                </div>
                 </div>
-                <div id="forcePrintDialog" title="Other Handouts" class="ui-dialog-titlebar ui-widget-header" style="overflow-x: hidden;">
+                <div id="forcePrintDialog" title="Other CHICA Handouts" class="ui-dialog-titlebar ui-widget-header" style="overflow-x: hidden;">
                     <div class="pws-force-print-content">
 			             <div class="force-print-forms-loading">
 			                 <span id="formsLoadingPanel"><img src="/openmrs/moduleResources/chica/images/ajax-loader.gif"/>Loading forms...</span>

--- a/web/module/resources/browserFixMobile.js
+++ b/web/module/resources/browserFixMobile.js
@@ -1,0 +1,13 @@
+// Fixes issues introduced in Chrome 43.  We had issues with scrolling, font size, and jumping pages
+// This can be removed from JSP pages once we upgrade to jquery mobile 1.4.5 or higher.
+$(document).on( "mobileinit", function() {
+	$.fn.animationComplete = function(callback) {
+       if ($.support.cssTransitions) {
+         var superfy= "WebKitTransitionEvent" in window ? "webkitAnimationEnd" : "animationend";
+         return $(this).one(superfy, callback);
+       } else {
+         setTimeout(callback, 0);
+         return $(this);
+       }
+     };
+});

--- a/web/module/resources/chicaMobile.css
+++ b/web/module/resources/chicaMobile.css
@@ -44,7 +44,7 @@ a[data-role="button"] {
     display: none;
 }
 
-@media screen and ( max-device-height: 2000px ){
+@media screen and ( max-device-height: 2100px ){
     .ui-btn-text, body, .ui-btn-inner, .ui-checkbox label, .ui-controlgroup-label,  .ui-controlgroup .ui-checkbox label, .ui-controlgroup .ui-radio label, .ui-radio label, .ui-body-a, .ui-body-a input, .ui-body-a select, .ui-body-a textarea, .ui-body-a button, .ui-btn-text, .ui-header .ui-title, .ui-content .ui.listview .ui-li-divider {
         font-size: 1.1em;
     }

--- a/web/module/resources/greaseBoard.js
+++ b/web/module/resources/greaseBoard.js
@@ -1,4 +1,3 @@
-var timer = null;
 var patientListFail = 0;
 var refreshPeriod = 30000;
 $(function() {
@@ -622,15 +621,6 @@ function startTimer(period) {
 	} else {
 		refreshPeriod = period * 1000;
 	}
-//	
-//    timer = $.timer(function () {
-//        populateList();
-//    });
-//
-//    timer.set({
-//        time: refreshPeriod,
-//        autostart: true
-//    });
     
     // This delay allows the wait cursor to display when loading the patient
 	// list.
@@ -778,7 +768,6 @@ function handlePatientListAjaxError(xhr, textStatus, error) {
 	        error = "The server took too long to retrieve the patient list.";
 	    }
 	    
-	    timer.pause();
 	    $("#listErrorResultDiv").html("<p>" + error + "  Click OK to try again.</p>");
 	    $("#listErrorDialog").dialog("open");
 	}

--- a/web/module/resources/pws.css
+++ b/web/module/resources/pws.css
@@ -7,6 +7,7 @@ body {
 
 .recommended-forms {
 	width:100%;
+	height:100%;
 	margin: 0;
 	padding: 0;
 }

--- a/web/module/resources/pws.js
+++ b/web/module/resources/pws.js
@@ -26,10 +26,10 @@ function parseAvailableJITs(responseXML) {
             var locationTagId = $(this).find("locationTagId").text();
             
         	formInstance = locationId + "_" + locationTagId + "_" + formId + "_" + formInstanceId;
-        	var action = "action=getPatientJITs&formInstances=" + formInstance + "#page=1&view=FitH,top&navpanes=0";
+        	var action = "action=getPatientJITs&formInstances=" + formInstance;
         	var url = "/openmrs/moduleServlet/chica/chica?";
         	tabList += '<li><a href="#tabs-' + count + '" title="' + formName + '">' + formName + '</a></li>';
-        	divList += '<div id="tabs-' + count + '" style="float:left;"><object type="application/pdf" class="recommended-forms" data="' + url + action + 
+        	divList += '<div id="tabs-' + count + '" style="float:left;height:100%"><object type="application/pdf" class="recommended-forms" data="' + url + action + 
             	'"><span style="color: #000;font-size:14px;">It appears your Web browser is not configured to display PDF files. ' +
             	'<a href="http://get.adobe.com/reader/" target="_blank"><font style="color: #0000FF;text-decoration: none; border-bottom: 1px solid #0000FF;">Click here to download the Adobe PDF Reader.</font></a>  ' + 
             	'Please restart your browser once the installation is complete.</span></object></div>';
@@ -50,10 +50,6 @@ function parseAvailableJITs(responseXML) {
         	}).addClass("ui-tabs-vertical ui-helper-clearfix");
             $("#tabs li").removeClass("ui-corner-top").addClass( "ui-corner-left");
             $('#tabs').show();
-            var divHeight = $("#formTabDialogContainer").height();
-            $(".recommended-forms").css({"height":divHeight});
-            $("#tabs").css({"height":divHeight});
-            $("#formTabDialogContainer").css("background", "#cc9966");
         }
     }
 }
@@ -274,6 +270,13 @@ $(function() {
         ]
     });
 	
+	var tabDivHeight = $(window).height() * 0.95 - 135;
+	$("#formTabDialogContainer").css({"height":tabDivHeight});
+	var divHeight = $(window).height() * 0.81;
+    $("#tabs").css({"height":tabDivHeight});
+    $("#formTabDialogContainer").css("background", "#cc9966");
+    $(".recommended-forms").css({"height":tabDivHeight});
+	
 	$("#forcePrintButton").click(function(event) {
 		$("#forcePrintDialog").dialog("open");
 		event.preventDefault();
@@ -327,4 +330,5 @@ $(function() {
     });
 	
 	$("#tabList").tooltip();
+	$("#formTabDialog").dialog("open");
   });

--- a/web/module/resources/pws.js
+++ b/web/module/resources/pws.js
@@ -26,7 +26,7 @@ function parseAvailableJITs(responseXML) {
             var locationTagId = $(this).find("locationTagId").text();
             
         	formInstance = locationId + "_" + locationTagId + "_" + formId + "_" + formInstanceId;
-        	var action = "action=getPatientJITs&formInstances=" + formInstance;
+        	var action = "action=getPatientJITs&formInstances=" + formInstance  + "#page=1&view=FitH,top&navpanes=0";
         	var url = "/openmrs/moduleServlet/chica/chica?";
         	tabList += '<li><a href="#tabs-' + count + '" title="' + formName + '">' + formName + '</a></li>';
         	divList += '<div id="tabs-' + count + '" style="float:left;height:100%"><object type="application/pdf" class="recommended-forms" data="' + url + action + 
@@ -272,7 +272,6 @@ $(function() {
 	
 	var tabDivHeight = $(window).height() * 0.95 - 135;
 	$("#formTabDialogContainer").css({"height":tabDivHeight});
-	var divHeight = $(window).height() * 0.81;
     $("#tabs").css({"height":tabDivHeight});
     $("#formTabDialogContainer").css("background", "#cc9966");
     $(".recommended-forms").css({"height":tabDivHeight});

--- a/web/module/resources/pws.js
+++ b/web/module/resources/pws.js
@@ -263,10 +263,6 @@ $(function() {
           effect: "fade",
           duration: 500
         },
-//        resize: function(e,ui) {
-//        	var divHeight = $("#formTabDialogContainer").height();
-//            $(".recommended-forms").css({"height":divHeight - 45});
-//        },
         resizable: false,
         buttons: [
           {
@@ -319,11 +315,6 @@ $(function() {
           effect: "fade",
           duration: 500
         },
-//        resize: function(e,ui) {
-//        	var divHeight = $(".pws-force-print-content").height();
-//    		// Update the height of the select
-//    		$(".force-print-forms").selectmenu().selectmenu("menuWidget").css({"max-height":(divHeight * 0.60) + "px"});
-//        },
         resizable: false,
         buttons: [
           {
@@ -336,5 +327,4 @@ $(function() {
     });
 	
 	$("#tabList").tooltip();
-	$("#formTabDialog").dialog("open");
   });

--- a/web/module/sexRiskMobile.jsp
+++ b/web/module/sexRiskMobile.jsp
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/moduleResources/chica/chicaMobile.css">
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery-1.9.1.min.js"></script>
+<script src="${pageContext.request.contextPath}/moduleResources/chica/browserFixMobile.js" charset="utf-8"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.mobile-1.3.2.min.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/jquery.blockUI.js"></script>
 <script src="${pageContext.request.contextPath}/moduleResources/chica/sexRiskMobile.js" charset="utf-8"></script>

--- a/web/src/org/openmrs/module/chica/web/ExternalFormController.java
+++ b/web/src/org/openmrs/module/chica/web/ExternalFormController.java
@@ -298,6 +298,12 @@ public class ExternalFormController extends SimpleFormController {
 	    return new ModelAndView(new RedirectView(formPage), map);
     }
     
+    /**
+     * Finds a patient in the system based on MRN.
+     * 
+     * @param mrn The patient's medical record number.
+     * @return A Patient in the system with the provided MRN or null if one cannot be found.
+     */
     private Patient getPatientByMRN(String mrn) {
     	PatientService patientService = Context.getPatientService();
 		List<PatientIdentifierType> types = new ArrayList<PatientIdentifierType>();
@@ -330,6 +336,17 @@ public class ExternalFormController extends SimpleFormController {
 	    return null;
     }
     
+    /**
+     * Retrieves the most recent encounter within the past two days that contains the provided start state but 
+     * not the end state for the provided form and patient.
+     * 
+     * @param patient Patient object
+     * @param backportsService ChirdlUtilBackportsService object
+     * @param startStateId The start state identifier
+     * @param endStateId The end state identifier
+     * @param formId The form identifier
+     * @return Encounter object or null if one is not found.
+     */
     private Encounter getRecentEncounter(Patient patient, ChirdlUtilBackportsService backportsService, Integer startStateId, 
                                          Integer endStateId, Integer formId) {
     	// Get last encounter with last day
@@ -368,6 +385,16 @@ public class ExternalFormController extends SimpleFormController {
 		return null;
     }
     
+    /**
+     * Gets the form instance information from the data provided
+     * 
+     * @param encounterId The encounter identifier
+     * @param formId The form identifier
+     * @param startStateId The start state identifier
+     * @param endStateId The end state identifier
+     * @param backportsService ChirdlUtilBackportsService object
+     * @return FormInstanceTag object or null if form information cannot be found.
+     */
     private FormInstanceTag getFormInstanceInfo(Integer encounterId, Integer formId, Integer startStateId, 
                                                 Integer endStateId, ChirdlUtilBackportsService backportsService) {
     	Map<Integer, List<PatientState>> formIdToPatientStateMapStart = new HashMap<Integer, List<PatientState>>();


### PR DESCRIPTION
We received some feedback from G3 about some things we should do on our physician-facing pages to inform users they are using CHICA.

1. Add the word CHICA on all pages displayed to the physician
2. Use the form display name instead of the actual form name.
3. When a form has already been submitted and someone tries to access the page, the current message states there isn't a valid form instance available. It should tell the user the form has already been submitted.
4. Attempt to get the Chrome PDF viewer to properly display the recommended handouts.
5. Fix bugs introduced (scrolling, font sizing, page jumping) by the Chrome 43 and Android System WebView updates introduced on devices running Android 5.0+.
6. Fix Greaseboard issue where it's supposed to display an error to the user after three failed load attempts of the patient list. Currently there's a javascript error.
7. Update the mobile Greaseboard to try loading the patient list three times before displaying an error to the user. This should give less error dialogs to the user.
