### PR TITLE
Chica 503 Changes to patient names and addresses were not updating correctly

### DIFF
--- a/metadata/config.xml
+++ b/metadata/config.xml
@@ -6,7 +6,7 @@
     <!-- Chica Module Properties -->
     <id>chica</id>
     <name>Chica</name>
-    <version>1.65.0</version>
+    <version>1.65.1</version>
     <package>org.openmrs.module.@MODULE_ID@</package>
     <author>Vibha Anand and Tammy Dugan</author>
     <description>

--- a/src/org/openmrs/module/chica/hl7/mckesson/HL7SocketHandler.java
+++ b/src/org/openmrs/module/chica/hl7/mckesson/HL7SocketHandler.java
@@ -867,7 +867,7 @@ public class HL7SocketHandler extends
 				public int compare(PersonName n1, PersonName n2) {
 					Date date1 = n1.getDateCreated();
 					Date date2 = n2.getDateCreated();
-					return date1.compareTo(date2) > 0 ? 0 : 1;
+					return date2.compareTo(date1);
 				}
 			});
 

--- a/src/org/openmrs/module/chica/hl7/mckesson/HL7SocketHandler.java
+++ b/src/org/openmrs/module/chica/hl7/mckesson/HL7SocketHandler.java
@@ -951,7 +951,7 @@ public class HL7SocketHandler extends
 				public int compare(PersonAddress a1, PersonAddress a2) {
 					Date date1 = a1.getDateCreated();
 					Date date2 = a2.getDateCreated();
-					return date1.compareTo(date2) > 0 ? 0 : 1;
+					return date2.compareTo(date1);
 				}
 			});
 


### PR DESCRIPTION
If a new name is entered for a patient via manual check-in or hl7, the most recent name/address should be the preferred value.