### PR TITLE
Chica 721 allow duplicate checkin for diff location

### DIFF
--- a/src/org/openmrs/module/chica/hl7/mckesson/HL7SocketHandler.java
+++ b/src/org/openmrs/module/chica/hl7/mckesson/HL7SocketHandler.java
@@ -84,6 +84,10 @@ import ca.uhn.hl7v2.validation.impl.NoValidation;
  * 
  */
 
+/**
+ * @author msheley
+ *
+ */
 public class HL7SocketHandler extends
 		org.openmrs.module.sockethl7listener.HL7SocketHandler {
 
@@ -1234,12 +1238,12 @@ public class HL7SocketHandler extends
 
 	}
 	
-	
 	/**
-	 * Checks if patient from this hl7 message already has an encounter today.
+	 * Checks if patient from this hl7 message already has an encounter today at the same location.
 	 * The message is saved to the sockethl7listener_patient_message table for record.
-	 * @param message
-	 * @return 
+	 * @param hl7message
+	 * @param locationString
+	 * @return
 	 */
 	private boolean priorCheckinExists(Message hl7message, String locationString) {
 

--- a/src/org/openmrs/module/chica/hl7/mckesson/HL7SocketHandler.java
+++ b/src/org/openmrs/module/chica/hl7/mckesson/HL7SocketHandler.java
@@ -1264,9 +1264,9 @@ public class HL7SocketHandler extends
 			}
 		
 			//Get all encounters for that patient from the start of the day
-			//CHICA-721 Only filter if location is at the same location.
+			//CHICA-721 Only filter if new registration location is the same as the first registration location.
 			//If a patient is registered at one clinic in error, and registered in another clinic afterward,
-			//allow that checkin, allow that checkin.
+			//allow that checkin.
 			Date startOfDay = DateUtils.truncate(new Date(), Calendar.DATE);
 			Location location = locationService.getLocation(locationString);
 			List<org.openmrs.Encounter> encounters = encounterService.getEncounters(patient, location, startOfDay, null,


### PR DESCRIPTION
Currently, after we receive an hl7 registration message, we check if there was a prior checkin exists for that patient for that day.  If there is , we do not check them into CHICA.  However, there have been times that a patient was registered with the wrong clinic, and then they register them again with the correct clinic.  We were not checking that patient in to CHICA.  This change does not filter the checkin, if the 2 registrations were at different clinics. This is clinic based and not printer location based.  